### PR TITLE
Fix: Wrong day of the week for a date

### DIFF
--- a/SSCalendar/SSCalendar/SSCalendar/CalenderView/SSCalendarView.swift
+++ b/SSCalendar/SSCalendar/SSCalendar/CalenderView/SSCalendarView.swift
@@ -145,7 +145,7 @@ extension SSCalendarView: UICollectionViewDataSource {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: monthCellID, for: indexPath) as? SSMonthCell else {
             return UICollectionViewCell()
         }
-        cell.configureCell(model: self.monthModels[indexPath.row], config: configuration)
+        cell.configureCell(model: self.monthModels[indexPath.row], config: configuration, weekStartDay: self.weekStartDay)
         DispatchQueue.global(qos: .background).async { [weak self] in
             guard let uSelf = self else {
                 return

--- a/SSCalendar/SSCalendar/SSCalendar/MonthCell/SSMonthCell.swift
+++ b/SSCalendar/SSCalendar/SSCalendar/MonthCell/SSMonthCell.swift
@@ -79,7 +79,8 @@ class SSMonthCell: UICollectionViewCell {
         }
     }
     
-    func configureCell(model: SSCalendarMonth, config: SSCalendarConfiguration) {
+    func configureCell(model: SSCalendarMonth, config: SSCalendarConfiguration, weekStartDay: WeekStartDay) {
+        self.weekStartDay = weekStartDay
         self.configuration = config
         self.monthModel = model
         self.currentMonth = model.monthNo


### PR DESCRIPTION
**Goals ⚽**
- Fix the wrong day of the week for a day when using `.sunday` as a `weekStartDay`

**Configuration and Steps to Reproduce 🐞🔄**

_Reproduced using:-_
Xcode: 15.2
Simulator: iPhone 15
iOS: 17.2

_Steps:-_
1. Change the `weekStartDay` to `.sunday` in `MainViewController.Swift`
2. Scroll down to second month from current month. E.g. if current month visible is January, scroll down till March
3. The date will be visible under the wrong day of the week

**Implementation Details 🚧**
- This PR fixes the wrong day of the week using the method injection of `weekStartDay` in the cell’s configuration

**Testing Details 🔍**
- No testing is needed as the change is in the comment.